### PR TITLE
fix download assets event

### DIFF
--- a/lib/cdnjs-view.coffee
+++ b/lib/cdnjs-view.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore-plus'
 fs = require 'fs'
 {$, $$, View, SelectListView} = require 'atom-space-pen-views'
 wget = require 'wget'
+path = require 'path'
 
 request = require 'superagent'
 module.exports =
@@ -17,7 +18,7 @@ class CdnjsView extends SelectListView
     super
 
     @addClass('overlay from-top')
-  
+
   destroy: ->
     @detach()
 
@@ -65,14 +66,15 @@ class CdnjsView extends SelectListView
 
   getFilterKey: ->
     'eventDescription'
-  
+
   toggle: (options = {}) ->
 
     @action = options.action || ''
     if @action == 'download'
       list = $('.tree-view-scroller')
-      selectedEntry = list.find('.selected')
-      @selectedPath = selectedEntry[0].directory.path
+      selectedEntry = list.find('.selected')[0]
+      entryEntity = selectedEntry.file || selectedEntry.directory
+      @selectedPath = if selectedEntry.file then path.dirname(entryEntity.path) else entryEntity.path
 
     if !@libraries
       @getLibraries()
@@ -109,7 +111,7 @@ class CdnjsView extends SelectListView
     @cancel()
     @setLoading('Please wait...')
     @show()
-    
+
     editor = atom.workspace.getActiveTextEditor()
 
     if eventName == 'version'
@@ -130,7 +132,7 @@ class CdnjsView extends SelectListView
         filePath = eventDescription.split('/')
         filePath = filePath[filePath.length-1]
         download = wget.download('http:' + url, @selectedPath + "/" + filePath, {})
-        
+
         download.on "end", (output) =>
 
           # show notification

--- a/lib/cdnjs.coffee
+++ b/lib/cdnjs.coffee
@@ -1,18 +1,21 @@
 CdnjsView = require './cdnjs-view'
 request = require 'superagent'
+{CompositeDisposable} = require 'atom'
 
 module.exports =
   cdnjsView: null
 
   activate: (state) ->
     @cdnjsView = new CdnjsView(state.cdnjsViewState)
-    atom.commands.add "atom-workspace",
-      "cdnjs:convert": => @convert()
+    @subscriptions = new CompositeDisposable
+
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      #"cdnjs:convert": => @convert()
       "cdnjs:GetUrl": => @GetUrl()
       "cdnjs:DownloadFile": => @DownloadFile()
-      "cdnjs:GetScriptTag": => @GetScriptTag()
-      "cdnjs:GetLinkTag": => @GetLinkTag()
-
+      #"cdnjs:GetScriptTag": => @GetScriptTag()
+      #"cdnjs:GetLinkTag": => @GetLinkTag()
+  
   url: ->
     @cdnjsView.toggle()
 
@@ -24,8 +27,8 @@ module.exports =
 
   GetLinkTag: ->
     @cdnjsView.toggle()
-  DownloadFile: ->
 
+  DownloadFile: ->
     @cdnjsView.toggle({action: 'download'})
 
   deactivate: ->

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "main": "./lib/cdnjs",
   "version": "1.5.0",
   "description": "Easily embed scripts from cdnjs",
-  "activationEvents": [
-    "cdnjs:GetUrl",
-    "cdnjs:DownloadFile"
-  ],
+  "activationCommands": {
+    "atom-text-editor": "cdnjs:GetUrl",
+    "atom-workspace": "cdnjs:DownloadFile"
+  },
   "repository": "https://github.com/cdnjs/atom-extension",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
- fix download assets event

`list.find('.selected')?.view()` is undefined `list.find('.selected')[0].directory.path ` used to get selected folder path or `list.find('.selected')[0].file.path` to get parent folder path.

- fix deprecated option 'activationEvents'

Use activationCommands instead of activationEvents in package.json. Commands should be grouped by selector

- added notification on asset downloaded

atom.notifications api used to this